### PR TITLE
alwaysFetch functionality for junction tables

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run Tests
         run: npm test
         
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: npm-logs

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -468,6 +468,27 @@ function handleTable(
     children.push(columnToASTChild(config.typeHint, namespace))
   }
 
+
+  // Handle junction alwaysFetch columns
+  if (fieldConfig.junction && fieldConfig.junction.alwaysFetch) {
+    const alwaysFetch = wrap(unthunk(
+      fieldConfig.junction.alwaysFetch,
+      sqlASTNode.args || {},
+      context
+    ))
+
+    for (let column of alwaysFetch) {
+      const columnChild = columnToASTChild(
+        unthunk(column, sqlASTNode.args || {}, context),
+        namespace
+      )
+      columnChild.fromOtherTable = sqlASTNode.junction.as
+    
+      // Add directly to children at this point, after all standard columns
+      sqlASTNode.children.push(columnChild);
+    }
+  }
+  
   // go handle the pagination information
   if (sqlASTNode.paginate) {
     handleColumnsRequiredForPagination(sqlASTNode, namespace)

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -485,7 +485,7 @@ function handleTable(
       columnChild.fromOtherTable = sqlASTNode.junction.as
     
       // Add directly to children at this point, after all standard columns
-      sqlASTNode.children.push(columnChild);
+      sqlASTNode.children.push(columnChild)
     }
   }
   

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -104,11 +104,21 @@ export default new GraphQLObjectType({
         }
       },
       resolve: (parent, args, context, resolveInfo) => {
-        return joinMonster(
-          resolveInfo,
-          context,
-          sql => dbCall(sql, knex, context),
-          options
+         // Add a hook to capture the SQL
+   
+         const sqlLogger = sql => {
+         // Store it in the context for the test to access
+            if (context && Object.prototype.hasOwnProperty.call(context, 'capturedSql')) {
+               context.capturedSql = sql
+            }
+            return dbCall(sql, knex, context)
+         }
+
+         return joinMonster(
+            resolveInfo,
+            context,
+            sqlLogger,
+            options
         )
       }
     },

--- a/test-api/schema-basic/User.js
+++ b/test-api/schema-basic/User.js
@@ -170,6 +170,7 @@ const User = new GraphQLObjectType({
               : false,
           junction: {
             sqlTable: q('relationships', DB),
+            alwaysFetch: ['closeness'],
             orderBy: args =>
               args.oldestFirst ? { followee_id: 'desc' } : null,
             where: (table, args) =>

--- a/test-api/schema-paginated/QueryRoot.js
+++ b/test-api/schema-paginated/QueryRoot.js
@@ -134,13 +134,24 @@ export default new GraphQLObjectType({
         }
       },
       resolve: (parent, args, context, resolveInfo) => {
-        return joinMonster(
-          resolveInfo,
-          context,
-          sql => dbCall(sql, knex, context),
-          options
+         // Add a hook to capture the SQL
+
+         const sqlLogger = sql => {
+         // Store it in the context for the test to access
+            if (context && Object.prototype.hasOwnProperty.call(context, 'capturedSql')) {
+               context.capturedSql = sql
+            }
+            return dbCall(sql, knex, context)
+         }
+
+         return joinMonster(
+            resolveInfo,
+            context,
+            sqlLogger,
+            options
         )
       }
+
     },
     post: {
       type: Post,

--- a/test-api/schema-paginated/User.js
+++ b/test-api/schema-paginated/User.js
@@ -260,6 +260,7 @@ const User = new GraphQLObjectType({
           },
           junction: {
             sqlTable: `(SELECT * FROM ${q('relationships', DB)})`,
+            alwaysFetch: ['closeness'],
             where: (table, args) =>
               args.intimacy
                 ? `${table}.${q('closeness', DB)} = '${args.intimacy}'`

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -52,14 +52,15 @@ test('should include alwaysFetch columns from junction table in SQL and not as t
   const selectMatch = context.capturedSql.toLowerCase().match(/select\s+([\s\S]+?)\s+from/i)
   t.truthy(selectMatch, 'Should match SELECT clause')
   
+  console.log(`sql = ${context.capturedSql}`)
   const selectClause = selectMatch[1]
     .split(',')
     .map(col => col.trim())
 
   // Find index of the closeness column
   const closenessIndex = selectClause.findIndex(col =>
-    col.includes('"following__closeness"') || col.includes('.closeness')
-  )
+  col.replace(/`/g, '').includes('following__closeness') || 
+  col.replace(/`/g, '').includes('closeness'))
 
   t.true(closenessIndex !== -1, 'SQL should include the closeness column')
   t.true(closenessIndex > 0, 'closeness column should not be the first column in the SELECT list')

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -33,3 +33,22 @@ test('should handle data from the junction table', async t => {
   }
   t.deepEqual(expect, data)
 })
+
+test('should include alwaysFetch columns from junction table in SQL', async t => {
+  const context = { capturedSql: '' }
+  
+  const source = `{
+    user(id: 3) {
+      fullName
+      following {
+        id
+      }
+    }
+  }`
+  
+  
+  await graphql({schema, source, contextValue: context})
+  
+  // Now check the captured SQL
+  t.true(context.capturedSql.includes('closeness'), 'SQL should include the closeness column')
+})

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -52,7 +52,6 @@ test('should include alwaysFetch columns from junction table in SQL and not as t
   const selectMatch = context.capturedSql.toLowerCase().match(/select\s+([\s\S]+?)\s+from/i)
   t.truthy(selectMatch, 'Should match SELECT clause')
   
-  console.log(`sql = ${context.capturedSql}`)
   const selectClause = selectMatch[1]
     .split(',')
     .map(col => col.trim())

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -34,7 +34,7 @@ test('should handle data from the junction table', async t => {
   t.deepEqual(expect, data)
 })
 
-test('should include alwaysFetch columns from junction table in SQL', async t => {
+test('should include alwaysFetch columns from junction table in SQL and not as the first column', async t => {
   const context = { capturedSql: '' }
   
   const source = `{
@@ -46,9 +46,22 @@ test('should include alwaysFetch columns from junction table in SQL', async t =>
     }
   }`
   
-  
   await graphql({schema, source, contextValue: context})
   
-  // Now check the captured SQL
-  t.true(context.capturedSql.includes('closeness'), 'SQL should include the closeness column')
+  // Extract the SELECT clause
+  const selectMatch = context.capturedSql.match(/SELECT\s+([\s\S]+?)\s+FROM/i)
+  t.truthy(selectMatch, 'Should match SELECT clause')
+  
+  const selectClause = selectMatch[1]
+    .split(',')
+    .map(col => col.trim())
+
+  // Find index of the closeness column
+  const closenessIndex = selectClause.findIndex(col =>
+    col.includes('"following__closeness"') || col.includes('.closeness')
+  )
+
+  t.true(closenessIndex !== -1, 'SQL should include the closeness column')
+  t.true(closenessIndex > 0, 'closeness column should not be the first column in the SELECT list')
 })
+

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -49,7 +49,7 @@ test('should include alwaysFetch columns from junction table in SQL and not as t
   await graphql({schema, source, contextValue: context})
   
   // Extract the SELECT clause
-  const selectMatch = context.capturedSql.match(/SELECT\s+([\s\S]+?)\s+FROM/i)
+  const selectMatch = context.capturedSql.toLowerCase().match(/select\s+([\s\S]+?)\s+from/i)
   t.truthy(selectMatch, 'Should match SELECT clause')
   
   const selectClause = selectMatch[1]


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/join-monster/join-monster/blob/master/CODE_OF_CONDUCT.md). Please see the [contributing guidelines](https://github.com/join-monster/join-monster/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The junction table functionality of join-monster exposes the alwaysFetch capability but did not implement it. It silently fails to do anything. This is needed otherwise when trying to leverage columns from the junction table the developer is left only with the junction "include" functionality which may force an unneeded change to the graphQL schema.

So in this PR we add the functionality for junction tables that had already been exposed but unimplemented. This requires no change in the documentation.

This is for the v3.3.5 release.


### References

see https://github.com/join-monster/join-monster/issues/548

### Testing

The current PR adds a simple test to ensure that the column is added to the select list. Pretty basic ... more will follow.


- [ x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ x] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
